### PR TITLE
ci: ignore _building/tmpl when running pytest. Template files can not…

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,7 +55,7 @@ jobs:
         cd ..
         python setup.py install
         cd -
-        sudo env "PATH=$PATH:$(npm bin)" pytest -v
+        sudo env "PATH=$PATH:$(npm bin)" pytest -v --ignore=_building
 
     - name: Test building doc
       run: |


### PR DESCRIPTION
… be run